### PR TITLE
fix: check if stream is a resource before closing it

### DIFF
--- a/lib/Horde/Stream.php
+++ b/lib/Horde/Stream.php
@@ -589,7 +589,7 @@ class Horde_Stream implements Serializable
      */
     public function close()
     {
-        if ($this->stream) {
+        if (is_resource($this->stream)) {
             fclose($this->stream);
         }
     }


### PR DESCRIPTION
Detected while developing https://github.com/bytestream/Imap_Client/pull/16.